### PR TITLE
Find functions name and ast nodes

### DIFF
--- a/file_parser.py
+++ b/file_parser.py
@@ -1,0 +1,51 @@
+import ast
+
+from collections import defaultdict
+from pathlib import Path
+
+
+def parse_tests(
+    filename: str,
+    source: str = None,
+) -> defaultdict[str, set]:
+    """
+    Parse test functions from a given source file.
+
+    Reads the source code from the given filename or directly
+    from the provided source string, parses the AST, and extracts all the
+    function names that start with "test". It returns a dictionary with
+    function names and their corresponding AST nodes.
+
+    Usage:
+
+    To parse test functions from a file:
+
+        >>> results = parse_tests("path/to/your/test_file.py")
+
+    To parse test functions from a string containing source code:
+
+        >>> parse_tests(source="def test():assert True", filename="test.py")
+        defaultdict(<class 'list'>, {'function_names': ['test'], 'nodes': [<ast.FunctionDef object at 0x104905690>]})
+
+    Returns:
+    defaultdict[str, list]
+        A default dict with two keys: 'function_names' and 'nodes'
+    """
+
+    if not source:
+        if Path(f"{filename}").exists():
+            with open(filename, "r") as file:
+                source = file.read()
+        else:
+            raise FileNotFoundError("File does not exist")
+
+    tree = ast.parse(source, filename=filename)
+    parse_results = defaultdict(list)
+
+    for node in ast.walk(tree):
+        match node:
+            case ast.FunctionDef(name=name) if name.startswith("test"):
+                parse_results["function_names"].append(name)
+
+    parse_results["nodes"] = tree.body
+    return parse_results

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,47 @@
+import pytest
+from unittest.mock import mock_open, patch
+from file_parser import parse_tests
+
+
+MOCK_SOURCE_CODE = """
+def test_func_one():
+    assert True
+
+def test_func_two():
+    assert False
+
+def not_a_test():
+    pass
+"""
+
+MOCK_FILE_PATH = "path/to/tests/test_file.py"
+
+
+def test_parse_tests_with_source_string():
+    source = MOCK_SOURCE_CODE
+
+    results = parse_tests(filename="test.py", source=source)
+
+    assert "test_func_one" in results["function_names"]
+    assert "test_func_two" in results["function_names"]
+    assert len(results["function_names"]) == 2
+    assert len(results["nodes"]) > 0
+
+
+def test_parse_tests_from_file():
+    m = mock_open(read_data=MOCK_SOURCE_CODE)
+
+    with patch("builtins.open", m), patch("pathlib.Path.exists", return_value=True):
+        results = parse_tests(filename=MOCK_FILE_PATH)
+
+        m.assert_called_once_with(MOCK_FILE_PATH, "r")
+        assert "test_func_one" in results["function_names"]
+        assert "test_func_two" in results["function_names"]
+        assert len(results["function_names"]) == 2
+        assert len(results["nodes"]) > 0
+
+
+def test_parse_tests_file_not_found():
+    with patch("pathlib.Path.exists", return_value=False):
+        with pytest.raises(FileNotFoundError):
+            parse_tests(filename=MOCK_FILE_PATH)


### PR DESCRIPTION
Implement `parse_tests`.

```python
>>> parse_tests(source="def test():assert True", filename="test.py")
defaultdict(<class 'list'>, {'function_names': ['test'], 'nodes': [<ast.FunctionDef object at 0x104905690>]})
```

Closes #2 